### PR TITLE
Fix references to build project.

### DIFF
--- a/Apps/UCosmic.Impl/UCosmic.Impl.csproj
+++ b/Apps/UCosmic.Impl/UCosmic.Impl.csproj
@@ -44,8 +44,9 @@
     <Reference Include="AutoMapper, Version=2.0.0.232, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AutoMapper.2.0.0\lib\net40-client\AutoMapper.dll</HintPath>
     </Reference>
-    <Reference Include="ComponentSpace.SAML2">
-      <HintPath>..\..\Libs\ComponentSpace.SAML2.dll</HintPath>
+    <Reference Include="ComponentSpace.SAML2, Version=2.4.0.6, Culture=neutral, PublicKeyToken=7c51d97b3a0a8ff9, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Etc\ComponentSpace.SAML2.dll</HintPath>
     </Reference>
     <Reference Include="Elmah">
       <HintPath>..\..\packages\elmah.corelibrary.1.2.1\lib\Elmah.dll</HintPath>

--- a/Tests/UCosmic.Www.Mvc.CodeFacts/UCosmic.Www.Mvc.CodeFacts.csproj
+++ b/Tests/UCosmic.Www.Mvc.CodeFacts/UCosmic.Www.Mvc.CodeFacts.csproj
@@ -46,8 +46,9 @@
     <Reference Include="AutoMapper">
       <HintPath>..\..\packages\AutoMapper.2.0.0\lib\net40-client\AutoMapper.dll</HintPath>
     </Reference>
-    <Reference Include="ComponentSpace.SAML2">
-      <HintPath>..\..\Libs\ComponentSpace.SAML2.dll</HintPath>
+    <Reference Include="ComponentSpace.SAML2, Version=2.4.0.6, Culture=neutral, PublicKeyToken=7c51d97b3a0a8ff9, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Etc\ComponentSpace.SAML2.dll</HintPath>
     </Reference>
     <Reference Include="Elmah, Version=1.1.11517.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\elmah.1.1\lib\Elmah.dll</HintPath>

--- a/ucosmic.sln
+++ b/ucosmic.sln
@@ -8,7 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8DF17FC7-E80E-4466-A34E-C8B86A1703EB}"
 	ProjectSection(SolutionItems) = preProject
 		Local.testsettings = Local.testsettings
-		README.markdown = README.markdown
+		README.md = README.md
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 		ucosmic.com.vsmdi = ucosmic.com.vsmdi
 	EndProjectSection


### PR DESCRIPTION
When Libs was renamed to Etc, forgot to update references in projects, so it did not build. References were updated and solution now builds.
